### PR TITLE
Initial implementation of the poipoi library

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ A small Clojure library for parsing raw osm.pbf (protocolbuffer binary format) f
 ;; Datafy osm pbf
    (datafy-osm-pbf input-stream)
 
-;; Where the `input-stream` is an instance of `java.io.InputStream` representing the osm.pbf file
+;; Where the `input-stream` is an instance of `java.io.InputStream` representing the osm.pbf file. Note that the evaluation of the datafy-osm-pbf function is lazy.
+
 ```
 ## Osm pbf files
 The raw pbf files this library is intended parse are located at

--- a/README.md
+++ b/README.md
@@ -4,7 +4,21 @@ A small Clojure library for parsing raw osm.pbf (protocolbuffer binary format) f
 
 ## Usage
 
-FIXME
+```clojure
+   [poipoi "0.1.0"]
+
+;; In your require statement:
+   [poipoi.core :refer [datafy-osm-pbf]]
+
+;; Datafy osm pbf
+   (datafy-osm-pbf input-stream)
+
+;; Where the `input-stream` is an instance of `java.io.InputStream` representing the osm.pbf file
+```
+## Osm pbf files
+The raw pbf files this library is intended parse are located at
+`download.geofabrik.de`.
+(https://download.geofabrik.de/north-america/us/rhode-island-latest.osm.pbf)
 
 ## License
 Release under the MIT license. See LICENSE for the full license.

--- a/project.clj
+++ b/project.clj
@@ -4,13 +4,6 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [org.clojure/data.csv "0.1.4"]
-                 [org.clojure/data.xml "0.0.8"]
-                 [org.clojure/tools.reader "1.3.2"]
-                 
-                 [cheshire "5.9.0"]
-                 [net.cgrand/xforms "0.19.0"]
-                 
                  [com.slimjars.trove4j/trove4j-long-list "1.0.1"]
                  [de.topobyte/osm4j-pbf "0.1.0"]
                  [de.topobyte/osm4j-xml "0.1.0"]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject poipoi "0.1.0-SNAPSHOT"
+(defproject poipoi "0.1.0"
   :description "A small Clojure library for parsing raw osm.pbf (protocolbuffer binary format) files into Clojure data structures."
   :url "https://github.com/robert-pierce/poipoi"
   :license {:name "Eclipse Public License"

--- a/src/poipoi/core.clj
+++ b/src/poipoi/core.clj
@@ -1,0 +1,22 @@
+(ns poipoi.core
+  (:require [clojure.core.protocols :refer [Datafiable]]
+            [clojure.datafy :refer [datafy]]
+            [poipoi.datafy-poi])
+  (:import [java.io InputStream]
+           [de.topobyte.osm4j.pbf.seq PbfIterator]))
+
+(defn pbf-iterator
+  [^InputStream is]
+  (PbfIterator. is true))
+
+(defn datafy-osm-iterator
+  [^PbfIterator pbfi]
+  (map datafy pbfi))
+
+(defn datafy-osm-pbf
+  [^InputStream is]
+  (try
+    (-> is
+        pbf-iterator
+        datafy-osm-iterator)
+    (catch Exception e (println "An error occured datafying the osm-pbf stream: " e))))

--- a/src/poipoi/core.clj
+++ b/src/poipoi/core.clj
@@ -5,11 +5,11 @@
   (:import [java.io InputStream]
            [de.topobyte.osm4j.pbf.seq PbfIterator]))
 
-(defn pbf-iterator
+(defn- pbf-iterator
   [^InputStream is]
   (PbfIterator. is true))
 
-(defn datafy-osm-iterator
+(defn- datafy-osm-iterator
   [^PbfIterator pbfi]
   (map datafy pbfi))
 

--- a/src/poipoi/datafy_poi.clj
+++ b/src/poipoi/datafy_poi.clj
@@ -17,7 +17,8 @@
 
 (defn- datafy-node
   [^Node n]
-  {:geo/lat (.getLatitude n)
+  {:osm/id  (.getId n)
+   :geo/lat (.getLatitude n)
    :geo/lng (.getLongitude n)
    :osm/tags (into {}
                    (map unpack-tag)
@@ -25,20 +26,23 @@
 
 (defn- datafy-relation
   [^Relation r]
-  {:tags (into {}
-               (map unpack-tag)
-               (.getTags r))
-   :members (map (fn [m]
-                   {:role (.getRole m)
+  {:osm/id      (.getId r)
+   :osm/tags    (into {}
+                      (map unpack-tag)
+                      (.getTags r))
+   :osm/members (map (fn [m]
+                   {:id   (.getId m)
+                    :role (.getRole m)
                     :type (entity-type->kwd (.getType m))})
                  (.getMembers r))})
 
 (defn- datafy-way
   [^Way w]
-  {:nodes (.toArray (.getNodes w))
-   :tags (into {}
-               (map unpack-tag)
-               (.getTags w))})
+  {:osm/id    (.getId w)
+   :osm/nodes (.toArray (.getNodes w))
+   :osm/tags  (into {}
+                (map unpack-tag)
+                (.getTags w))})
 
 (defn- datafy-entity-container
   [^EntityContainer this]

--- a/src/poipoi/datafy_poi.clj
+++ b/src/poipoi/datafy_poi.clj
@@ -1,0 +1,62 @@
+(ns poipoi.datafy-poi
+  (:require [clojure.core.protocols :refer [Datafiable]]
+            [clojure.datafy :refer [datafy]])
+  (:import [de.topobyte.osm4j.core.model.iface EntityContainer EntityType]
+           [de.topobyte.osm4j.core.model.impl Node Relation Way Tag]))
+
+(def entity-type->kwd
+  {EntityType/Node     :node
+   EntityType/Relation :relation
+   EntityType/Way      :way})
+
+(defn- unpack-tag
+  [^Tag t]
+  (let [k (.getKey t)
+        v (.getValue t)]
+    [k v]))
+
+(defn- datafy-node
+  [^Node n]
+  {:geo/lat (.getLatitude n)
+   :geo/lng (.getLongitude n)
+   :osm/tags (into {}
+                   (map unpack-tag)
+                   (.getTags n))})
+
+(defn- datafy-relation
+  [^Relation r]
+  {:tags (into {}
+               (map unpack-tag)
+               (.getTags r))
+   :members (map (fn [m]
+                   {:role (.getRole m)
+                    :type (entity-type->kwd (.getType m))})
+                 (.getMembers r))})
+
+(defn- datafy-way
+  [^Way w]
+  {:nodes (.toArray (.getNodes w))
+   :tags (into {}
+               (map unpack-tag)
+               (.getTags w))})
+
+(defn- datafy-entity-container
+  [^EntityContainer this]
+  (let [entity-pojo (.getEntity this)
+        entity-data (datafy entity-pojo)]
+    (-> {:osm/type (entity-type->kwd (.getType this))}
+        (merge entity-data)
+        (with-meta {:osm/entity entity-pojo}))))
+
+(extend-protocol Datafiable
+  EntityContainer
+  (datafy [this] (datafy-entity-container this))
+
+  Node
+  (datafy [this] (datafy-node this))
+
+  Relation
+  (datafy [this] (datafy-relation this))
+
+  Way
+  (datafy [this] (datafy-way this)))


### PR DESCRIPTION
This PR provides the initial implementation of the poipoi library. This library is designed to parse raw osm.pbf files into Clojure data structures.